### PR TITLE
Prevent from crashing on TypeScript errors during Karma launch. Fixes #3

### DIFF
--- a/trx.js
+++ b/trx.js
@@ -31,11 +31,11 @@ function escape(str) {
 };
 
 module.exports = function (testResults) {
-    var start = finish = null;
+    var start = Math.min.apply(testResults.specs.map(spec => spec.start.getTime()));
+    var finish = Math.max.apply(testResults.specs.map(spec => spec.finish.getTime()));
 
-    if(testResults.specs.length) {
-        start = Math.min.apply(testResults.specs.map(spec => spec.start.getTime()));
-        finish = Math.max.apply(testResults.specs.map(spec => spec.finish.getTime()));
+    if(!testResults.specs.length) {
+        start = finish = new Date();
     }
 
     var specs = testResults.specs.map(spec => {

--- a/trx.js
+++ b/trx.js
@@ -31,8 +31,12 @@ function escape(str) {
 };
 
 module.exports = function (testResults) {
-    var start = Math.min.apply(null, testResults.specs.map(spec => spec.start.getTime()));
-    var finish = Math.max.apply(null, testResults.specs.map(spec => spec.finish.getTime()));
+    var start = finish = null;
+
+    if(testResults.specs.length) {
+        start = Math.min.apply(testResults.specs.map(spec => spec.start.getTime()));
+        finish = Math.max.apply(testResults.specs.map(spec => spec.finish.getTime()));
+    }
 
     var specs = testResults.specs.map(spec => {
         spec.suite = escape(spec.suite);

--- a/trx.js
+++ b/trx.js
@@ -31,8 +31,8 @@ function escape(str) {
 };
 
 module.exports = function (testResults) {
-    var start = Math.min.apply(testResults.specs.map(spec => spec.start.getTime()));
-    var finish = Math.max.apply(testResults.specs.map(spec => spec.finish.getTime()));
+    var start = Math.min.apply(null, testResults.specs.map(spec => spec.start.getTime()));
+    var finish = Math.max.apply(null, testResults.specs.map(spec => spec.finish.getTime()));
 
     if(!testResults.specs.length) {
         start = finish = new Date();


### PR DESCRIPTION
When TypeScript fails on Karma launch, specs do not have a start or finish timestamps. This lead to the setting of the date to: `Infinity` with can't be parsed to Date object.

In this case, I propose to just use current karma run date as a placeholder.